### PR TITLE
Fix/bail out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Nero (aka the Neovim REPL)
 
+[![Maintainability](https://api.codeclimate.com/v1/badges/69f29a4a3c00b35eb771/maintainability)](https://codeclimate.com/github/Vigemus/nero.nvim/maintainability)
+
+[![Test Coverage](https://api.codeclimate.com/v1/badges/69f29a4a3c00b35eb771/test_coverage)](https://codeclimate.com/github/Vigemus/nero.nvim/test_coverage)
+
+[![Known Vulnerabilities](https://snyk.io/test/github/Vigemus/nero.nvim/badge.svg?targetFile=build.sbt)](https://snyk.io/test/github/Vigemus/nero.nvim?targetFile=build.sbt)
+
 Nero is a very simple Neovim REPL.
 
 It connects to neovim using RPC infrastructure and allows you to read-eval-print-loop over the

--- a/bin/dev-run
+++ b/bin/dev-run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sbt assembly && java -jar target/scala-2.12/nero.jar

--- a/bin/nero
+++ b/bin/nero
@@ -3,4 +3,4 @@ BIN_DIR="$(dirname "$(realpath "$0")")"
 NERO_DIR="$(dirname "$BIN_DIR")"
 INSTALL_DIR="$NERO_DIR/target/scala-2.12"
 
-echo java -jar "$INSTALL_DIR/nero.jar"
+java -jar "$INSTALL_DIR/nero.jar"

--- a/bin/nero
+++ b/bin/nero
@@ -1,0 +1,6 @@
+#!/bin/bash
+BIN_DIR="$(dirname "$(realpath "$0")")"
+NERO_DIR="$(dirname "$BIN_DIR")"
+INSTALL_DIR="$NERO_DIR/target/scala-2.12"
+
+echo java -jar "$INSTALL_DIR/nero.jar"

--- a/src/main/scala/nero/Main.scala
+++ b/src/main/scala/nero/Main.scala
@@ -1,13 +1,32 @@
 package nero
 
 import scala.util.control.TailCalls._
+import scala.util.control.NoStackTrace
 import java.io.{PrintStream, OutputStream, InputStream}
 import scala.io.StdIn
 import java.net.Socket
 
 
-trait REPL {
+object REPL {
   case class ReplState(nvim: Neovim, currentMode: Lang)
+  case class NeroError(val message: String) extends NoStackTrace with ReplResponse
+
+  def replToString(msg: ReplResponse): String = msg match {
+    case NeovimNop => "[NOP ]"
+    case NeovimMessage(msg) => s"[OK  ] $msg"
+    case NeovimError(msg) => s"[FAIL] $msg"
+    case NeroError(msg) => s"[ERR ] $msg"
+  }
+  val ps: PrintStream = new PrintStream(System.out)
+  def out(msg: ReplResponse) = ps.println(replToString(msg))
+
+  def reload(pkg: String): String = s"""
+  | for pkg, _ in pairs(package.loaded) do
+  |   if pkg:sub(${pkg.size}) == "${pkg}" then
+  |     package.loaded[pkg] = nil
+  |   end
+  | end""".stripMargin('|')
+
 
   def handleCommands(state: ReplState, args: String*): TailRec[ReplState] = {
     val cmd :: arguments = args.toList
@@ -15,6 +34,11 @@ trait REPL {
 
     cmd match {
       case x if Set(":q", ":q!", ":quit", ":quit!", ":wq", ":x:") contains x => done(state)
+      case ":reload" => {
+        val pkg :: _ = arguments
+        out(state.nvim.send(Lua, reload(pkg)))
+        recur(state)
+      }
       case ":set" => {
         val lang :: _ = arguments
         lang match {
@@ -23,13 +47,12 @@ trait REPL {
         }
       }
       case x => {
-        ps.println(s"[Err ]   '$x' is not a repl command")
+        out(NeroError(s"'${x}' is not a repl command"))
         recur(state)
       }
     }
   }
 
-  val ps: PrintStream = new PrintStream(System.out)
 
   final def repl(state: ReplState): TailRec[ReplState] = {
     val prompt = state.currentMode match {
@@ -40,20 +63,21 @@ trait REPL {
     StdIn.readLine(prompt) match {
       case cmd if cmd.startsWith(":") => handleCommands(state, cmd.split(" "):_*)
       case cmd => tailcall{
-        val resp = state.nvim.send(state.currentMode, cmd)
-        ps.println(resp)
+        out(state.nvim.send(state.currentMode, cmd))
         repl(state)
       }
     }
   }
 
+  def run(nvim: Neovim, currentMode: Lang = Lua): ReplState = repl(ReplState(nvim, currentMode)).result
+
 }
 
-object Main extends REPL {
+object Main {
   def main(args: Array[String]): Unit = {
     val nvim = Neovim.fromSocket(new Socket("127.0.0.1", 12345))
 
-    repl(ReplState(nvim, Lua)).result
+    REPL.run(nvim)
 
     nvim.close()
   }


### PR DESCRIPTION
This makes repl experience much better by not hanging/crashing if command fails to execute on neovim.

Also, it makes rendering logic part of `nero.Repl` only.

More work on splitting things need to be done nonetheless.

It also lays ground for `:reload`/`:unload` commands (to speed refreshing modules).

Finally, it adds `bin/nero` and `bin/run-dev`.